### PR TITLE
Fix posi abs position update

### DIFF
--- a/software/modules/posi/include/Posi.h
+++ b/software/modules/posi/include/Posi.h
@@ -38,6 +38,8 @@ public:
 
 private:
   std::shared_ptr<IBaseTime> time_helper_;
+  long previous_encoder1_;
+  long previous_encoder2_;
   double abs_pos_x_;
   double abs_pos_y_;
   double orientation_;

--- a/software/modules/posi/src/Posi.cpp
+++ b/software/modules/posi/src/Posi.cpp
@@ -36,15 +36,11 @@ void Posi::updatePosition(int encoder1, int encoder2) {
   // Reset timestamp
   timestamp_ = time_now;
 
-  // Convert ticks into angular speed
-  double speed_left_wheel_radps =
-      (WHEEL_PERIMETER * encoder1 / TICKS_PER_ROTATION);
-  double speed_right_wheel_radps =
-      (WHEEL_PERIMETER * encoder2 / TICKS_PER_ROTATION);
-
   // Linear speed
-  double speed_left_wheel_ms = WHEEL_RADIUS_M * speed_left_wheel_radps;
-  double speed_right_wheel_ms = WHEEL_RADIUS_M * speed_right_wheel_radps;
+  double speed_left_wheel_ms =
+      (WHEEL_PERIMETER * encoder1 / TICKS_PER_ROTATION);
+  double speed_right_wheel_ms =
+      (WHEEL_PERIMETER * encoder2 / TICKS_PER_ROTATION);
 
   // Average speed
   double average_speed = (speed_left_wheel_ms + speed_right_wheel_ms) / 2;

--- a/software/modules/posi/src/Posi.cpp
+++ b/software/modules/posi/src/Posi.cpp
@@ -8,9 +8,9 @@ const double WHEEL_PERIMETER = M_PI * 2 * WHEEL_RADIUS_M;
 
 Posi::Posi(std::shared_ptr<IBaseTime> time_helper, double &start_pos_x,
            double &start_pos_y, double &start_orientation)
-    : time_helper_(std::move(time_helper)), abs_pos_x_(start_pos_x),
-      abs_pos_y_(start_pos_y), orientation_(start_orientation),
-      timestamp_(time_helper_->getNow()) {}
+    : time_helper_(std::move(time_helper)), previous_encoder1_(0),
+      previous_encoder2_(0), abs_pos_x_(start_pos_x), abs_pos_y_(start_pos_y),
+      orientation_(start_orientation), timestamp_(time_helper_->getNow()) {}
 
 void Posi::getPosition(double &pos_x, double &pos_y,
                        double &orientation) const {
@@ -36,11 +36,15 @@ void Posi::updatePosition(int encoder1, int encoder2) {
   // Reset timestamp
   timestamp_ = time_now;
 
+  // Delta encoders
+  auto delta_encoder1 = encoder1 - previous_encoder1_;
+  auto delta_encoder2 = encoder2 - previous_encoder2_;
+
   // Linear speed
   double speed_left_wheel_ms =
-      (WHEEL_PERIMETER * encoder1 / TICKS_PER_ROTATION);
+      (WHEEL_PERIMETER * delta_encoder1 / TICKS_PER_ROTATION);
   double speed_right_wheel_ms =
-      (WHEEL_PERIMETER * encoder2 / TICKS_PER_ROTATION);
+      (WHEEL_PERIMETER * delta_encoder2 / TICKS_PER_ROTATION);
 
   // Average speed
   double average_speed = (speed_left_wheel_ms + speed_right_wheel_ms) / 2;
@@ -57,4 +61,8 @@ void Posi::updatePosition(int encoder1, int encoder2) {
   abs_pos_x_ = abs_pos_x_ + delta_position_x * delta_time_s;
   abs_pos_y_ = abs_pos_y_ + delta_position_y * delta_time_s;
   orientation_ = orientation_ + delta_orientation * delta_time_s;
+
+  // Update previous encoders with current ones
+  previous_encoder1_ = encoder1;
+  previous_encoder2_ = encoder2;
 }

--- a/software/modules/posi/test/PosiTest.cpp
+++ b/software/modules/posi/test/PosiTest.cpp
@@ -6,8 +6,8 @@
 double const DOUBLE_NEAR_FACTOR = 0.00001;
 
 TEST(PosiTest, whenGettingNewTicks_absolutePositionShouldBeUpdatedAccordingly) {
-  double start_pox_x = 1;
-  double start_pos_y = 1;
+  double start_pox_x = 0;
+  double start_pos_y = 0;
   double orientation = 0;
 
   // Simulates a delta time of 1000 ms
@@ -26,7 +26,7 @@ TEST(PosiTest, whenGettingNewTicks_absolutePositionShouldBeUpdatedAccordingly) {
 
   posi->getPosition(new_abs_pos_x, new_abs_pos_y, new_abs_orientation);
 
-  EXPECT_NEAR(new_abs_pos_x, 1.01396, DOUBLE_NEAR_FACTOR);
-  EXPECT_NEAR(new_abs_pos_y, 1, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_pos_x, 0.01396, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_pos_y, 0, DOUBLE_NEAR_FACTOR);
   EXPECT_NEAR(new_abs_orientation, 0.48869, DOUBLE_NEAR_FACTOR);
 }

--- a/software/modules/posi/test/PosiTest.cpp
+++ b/software/modules/posi/test/PosiTest.cpp
@@ -26,7 +26,7 @@ TEST(PosiTest, whenGettingNewTicks_absolutePositionShouldBeUpdatedAccordingly) {
 
   posi->getPosition(new_abs_pos_x, new_abs_pos_y, new_abs_orientation);
 
-  EXPECT_NEAR(new_abs_pos_x, 0.01396, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_pos_x, 0.13962, DOUBLE_NEAR_FACTOR);
   EXPECT_NEAR(new_abs_pos_y, 0, DOUBLE_NEAR_FACTOR);
-  EXPECT_NEAR(new_abs_orientation, 0.48869, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_orientation, 4.88692, DOUBLE_NEAR_FACTOR);
 }

--- a/software/modules/posi/test/PosiTest.cpp
+++ b/software/modules/posi/test/PosiTest.cpp
@@ -30,3 +30,33 @@ TEST(PosiTest, whenGettingNewTicks_absolutePositionShouldBeUpdatedAccordingly) {
   EXPECT_NEAR(new_abs_pos_y, 0, DOUBLE_NEAR_FACTOR);
   EXPECT_NEAR(new_abs_orientation, 4.88692, DOUBLE_NEAR_FACTOR);
 }
+
+TEST(
+    PosiTest,
+    whenPositionUpdatedMultipleTimes_absolutePositionShouldBeUpdatedAccordingly) {
+
+  double start_pox_x = 0;
+  double start_pos_y = 0;
+  double orientation = 0;
+
+  // Simulates a delta time of 1000 ms
+  auto time_helper = std::make_shared<FakeTime>(1000);
+
+  auto posi = std::make_shared<Posi>(time_helper, start_pox_x, start_pos_y,
+                                     orientation);
+
+  // Position updated twice to check if the previous ticks where taken into
+  // account
+  posi->updatePosition(360, 360);
+  posi->updatePosition(720, 720); // Same speed so 360 * 2
+
+  double new_abs_pos_x = 0;
+  double new_abs_pos_y = 0;
+  double new_abs_orientation = 0;
+
+  posi->getPosition(new_abs_pos_x, new_abs_pos_y, new_abs_orientation);
+
+  EXPECT_NEAR(new_abs_pos_x, 1.25663, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_pos_y, 0, DOUBLE_NEAR_FACTOR);
+  EXPECT_NEAR(new_abs_orientation, 0, DOUBLE_NEAR_FACTOR);
+}


### PR DESCRIPTION
Two bugs where found in posi abs position calcul and fixed in this PR:

- Wrong units used (no angular speed but was linear) which caused a wrong position result by a factor of 10x.
- The updatePosition method was assuming to receive a delta tick from the last update and not an absolute one.