### PR TITLE
[cmake] add condition enable_gui

### DIFF
--- a/software/CMakeLists.txt
+++ b/software/CMakeLists.txt
@@ -20,15 +20,17 @@ if (CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
 endif ()
 
-# gRPC flags
-set(gRPC_BUILD_CSHARP_EXT OFF)
-set(gRPC_BUILD_GRPC_CSHARP_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_PHP_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_NODE_PLUGIN OFF)
-set(gRPC_BUILD_TESTS OFF)
+if (ENABLE_GUI)
+    # gRPC flags
+    set(gRPC_BUILD_CSHARP_EXT OFF)
+    set(gRPC_BUILD_GRPC_CSHARP_PLUGIN OFF)
+    set(gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN OFF)
+    set(gRPC_BUILD_GRPC_PHP_PLUGIN OFF)
+    set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF)
+    set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF)
+    set(gRPC_BUILD_GRPC_NODE_PLUGIN OFF)
+    set(gRPC_BUILD_TESTS OFF)
+endif ()
 
 project(couscous
         VERSION 1.0
@@ -36,7 +38,10 @@ project(couscous
 
 add_subdirectory(modules)
 add_subdirectory(applications)
-add_subdirectory(application_test_gui)
-add_subdirectory(external/grpc)
-add_subdirectory(external/googletest)
 
+if (ENABLE_GUI)
+    add_subdirectory(application_test_gui)
+    add_subdirectory(external/grpc)
+endif ()
+
+add_subdirectory(external/googletest)

--- a/software/applications/CMakeLists.txt
+++ b/software/applications/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 3.0)
 project(applications)
 
-add_subdirectory(application_1)
-add_subdirectory(application_integration)
+if(ENABLE_GUI)
+    add_subdirectory(application_1)
+    add_subdirectory(application_integration)
+endif()

--- a/software/modules/CMakeLists.txt
+++ b/software/modules/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required (VERSION 3.0)
 project(modules)
 
-add_subdirectory(gui)
+if(ENABLE_GUI)
+    add_subdirectory(gui)
+endif()
 add_subdirectory(hali)
 add_subdirectory(moti)
 add_subdirectory(posi)


### PR DESCRIPTION
This PR define the flag ENBALE_GUI that is requiered for the module GUI and the app using the GUI
This flag allow fast compile time for other modules and avoid need of all GUI related submodules