### PR TITLE
Add spdlog library to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build/
 
 #external libs folder
 software/external
+
+# log
+couscous.log

--- a/software/CMakeLists.txt
+++ b/software/CMakeLists.txt
@@ -24,6 +24,11 @@ project(couscous
         VERSION 1.0
         )
 
+if(NOT TARGET spdlog)
+    find_package(spdlog REQUIRED)
+endif()
+
+add_subdirectory(libs)
 add_subdirectory(modules)
 add_subdirectory(applications)
 add_subdirectory(external/googletest)

--- a/software/libs/CMakeLists.txt
+++ b/software/libs/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required (VERSION 3.0)
+project(libs)
+
+add_subdirectory(logger)

--- a/software/libs/logger/CMakeLists.txt
+++ b/software/libs/logger/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(logger LANGUAGES CXX)
+
+list(APPEND SOURCES
+    src/LoggerFactory.cpp
+)
+
+file(GLOB_RECURSE HEADERS include/*.h)
+
+add_compile_definitions(LOG_DIR="/workspace/laughing-couscous/")
+
+# Library
+add_library(
+    ${PROJECT_NAME}_lib
+    STATIC ${SOURCES}
+    ${HEADERS}
+)
+
+target_include_directories(
+    ${PROJECT_NAME}_lib
+    PUBLIC include
+    PRIVATE src
+)
+    
+target_link_libraries(${PROJECT_NAME}_lib 
+    PUBLIC spdlog::spdlog
+)

--- a/software/libs/logger/include/logger/LoggerFactory.h
+++ b/software/libs/logger/include/logger/LoggerFactory.h
@@ -1,0 +1,18 @@
+#ifndef LOGGERFACTORY_H
+#define LOGGERFACTORY_H
+
+#include <memory>
+#include <string>
+
+#include "spdlog/spdlog.h"
+
+class LoggerFactory {
+   public:
+    LoggerFactory() = default;
+
+    static std::shared_ptr<spdlog::logger> registerOrGetLogger(
+        const std::string &logger_name,
+        spdlog::level::level_enum logger_level);
+};
+
+#endif  // LOGGERFACTORY_H

--- a/software/libs/logger/src/LoggerFactory.cpp
+++ b/software/libs/logger/src/LoggerFactory.cpp
@@ -1,0 +1,39 @@
+#include "logger/LoggerFactory.h"
+
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+#include <experimental/filesystem>
+#include <regex>
+
+std::shared_ptr<spdlog::logger> LoggerFactory::registerOrGetLogger(
+    const std::string &logger_name,
+    spdlog::level::level_enum logger_level) {
+    auto logger = spdlog::get(logger_name);
+
+    if (logger) {
+        logger->set_level(logger_level);
+        return logger;
+    }
+
+    // Create static sinks to have them only created once and shared between loggers
+    static auto stdout_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    std::vector<spdlog::sink_ptr> sinks{stdout_sink};
+
+    const auto *log_file = LOG_DIR "couscous.log";
+    static auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_file);
+    sinks.push_back(file_sink);
+
+    // Create combined logger
+    logger = std::make_shared<spdlog::logger>(logger_name, sinks.begin(), sinks.end());
+
+    spdlog::register_logger(logger);
+
+    // reference: https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
+    static std::string std_pattern_format = "[%Y-%m-%dT%H:%M:%S.%f][%n][%l][%s:%#] %v";
+    logger->set_pattern(std_pattern_format);
+
+    logger->set_level(logger_level);
+
+    return logger;
+}

--- a/software/modules/posi/CMakeLists.txt
+++ b/software/modules/posi/CMakeLists.txt
@@ -29,7 +29,13 @@ target_include_directories(
     PUBLIC include
     PRIVATE src
 )
+    
+target_link_libraries(${PROJECT_NAME}_lib 
+    PUBLIC 
+    logger_lib 
+    spdlog::spdlog
+)
 
 # Tests Binaries
 add_executable(${PROJECT_NAME}_test ${TESTS})
-target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME}_lib gtest_main)
+target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME}_lib gtest_main logger_lib spdlog::spdlog)

--- a/software/modules/posi/include/Posi.h
+++ b/software/modules/posi/include/Posi.h
@@ -1,6 +1,8 @@
 #ifndef POSI_H
 #define POSI_H
 
+#include <spdlog/logger.h>
+
 #include <memory>
 
 #include "IBaseTime.h"
@@ -41,6 +43,7 @@ class Posi {
     void updatePosition(int encoder1, int encoder2);
 
    private:
+    std::shared_ptr<spdlog::logger> logger_;
     std::shared_ptr<IBaseTime> time_helper_;
     long previous_encoder1_;
     long previous_encoder2_;

--- a/software/modules/posi/src/Posi.cpp
+++ b/software/modules/posi/src/Posi.cpp
@@ -1,6 +1,11 @@
 #include "Posi.h"
 
+#include <spdlog/logger.h>
+
 #include <cmath>
+#include <iostream>
+
+#include "logger/LoggerFactory.h"
 
 const int TICKS_PER_ROTATION = 360;
 const double SPACE_BETWEEN_WHEELS = 0.2;
@@ -12,7 +17,8 @@ Posi::Posi(
     double &start_pos_x,
     double &start_pos_y,
     double &start_orientation)
-    : time_helper_(std::move(time_helper)),
+    : logger_(LoggerFactory::registerOrGetLogger("Posi", spdlog::level::level_enum::debug)),
+      time_helper_(std::move(time_helper)),
       previous_encoder1_(0),
       previous_encoder2_(0),
       abs_pos_x_(start_pos_x),
@@ -68,4 +74,11 @@ void Posi::updatePosition(int encoder1, int encoder2) {
     // Update previous encoders with current ones
     previous_encoder1_ = encoder1;
     previous_encoder2_ = encoder2;
+
+    SPDLOG_LOGGER_INFO(
+        logger_,
+        "Update position x: {} - y: {} - orientation: {}",
+        abs_pos_x_,
+        abs_pos_y_,
+        orientation_);
 }

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -95,3 +95,11 @@ RUN cmake -DCMAKE_TOOLCHAIN_FILE=/tmp/toolchain.cmake \
     -DCMAKE_INSTALL_PREFIX=/tmp/raspberrypi_root/grpc_install \
     ../.. && \
     make -j$(nproc) install
+
+
+# Install spdlog library
+WORKDIR /tmp
+
+RUN git clone https://github.com/gabime/spdlog.git && \
+    cd spdlog && mkdir build && cd build && \
+    cmake .. && make -j$(nproc) install


### PR DESCRIPTION
- add [spdlog](https://github.com/gabime/spdlog) library to project
- dockerfile has been updated, build and install spdlog lib at docker image building
- A spdlog wrapper has been added in order to provide a factory that will always target the same file
- Posi already uses the logger as an example

WARNING: The docker image has to be rebuilt, but don't worry guys it doesn't rebuild everything just the spdlog library which takes about 10 seconds